### PR TITLE
`function` doesn't work for functions with one character names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 /npm-debug.log
 /.lintcache
+/.idea

--- a/function.js
+++ b/function.js
@@ -25,6 +25,8 @@ module.exports = function (name) {
 				while (++j !== l) {
 					if (code[++i] !== name[j]) return $common;
 				}
+			} else {
+				--i;
 			}
 			while (hasOwnProperty.call(wsSet, code[++i])) continue; //jslint: ignore
 			if (code[i] !== '(') return $common;

--- a/test/function.js
+++ b/test/function.js
@@ -7,7 +7,7 @@ var readFile = require('fs').readFile
 
 module.exports = function (t, a, d) {
 	readFile(pg + '/function.js', 'utf-8', function (err, str) {
-		var plainR, astR;
+		var plainR, astR, oneChar;
 		if (err) {
 			d(err);
 			return;
@@ -16,6 +16,8 @@ module.exports = function (t, a, d) {
 		astR = ast(str);
 		a(plainR.length, astR.length, "Length");
 		astR.forEach(function (val, i) { a.deep(plainR[i], val, i); });
+		oneChar = t('a')('a()');
+		a(oneChar.length, 1, "Is one characterd named function working?");
 		d();
 	});
 };


### PR DESCRIPTION
Example:

``` javascript
'use strict';

var findUnder = require('esniff/function')('a');

console.log(findUnder('var x = a(\'foo/bar\')')); //[]
```
